### PR TITLE
Add 'keep' option to 'behavior.on.null.values' config

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -587,7 +587,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           BehaviorOnNullValues.VALIDATOR,
           Importance.LOW,
           "How to handle records with a null value (i.e. Kafka tombstone records)."
-              + " Valid options are 'ignore' and 'fail'.",
+              + " Valid options are 'ignore', 'fail', and 'keep'",
           group,
           ++orderInGroup,
           Width.SHORT,
@@ -1079,7 +1079,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public enum BehaviorOnNullValues {
     IGNORE,
-    FAIL;
+    FAIL,
+    KEEP;
 
     public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
       private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -257,7 +257,8 @@ public class S3SinkTask extends SinkTask {
             record.kafkaOffset()
         );
         return true;
-      } else {
+      } else if (connectorConfig.nullValueBehavior()
+          .equalsIgnoreCase(BehaviorOnNullValues.FAIL.toString())) {
         throw new ConnectException("Null valued records are not writeable with current "
             + S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG + " 'settings.");
       }


### PR DESCRIPTION
This option allows for keeping `null` values, which allows for persisting
tombstone records.

